### PR TITLE
Full resource tree retrieval via IPC

### DIFF
--- a/Helpers/FuncSubscriber.cs
+++ b/Helpers/FuncSubscriber.cs
@@ -123,6 +123,35 @@ public readonly struct FuncSubscriber<T1, T2, TRet>
 }
 
 /// <inheritdoc cref="FuncSubscriber{TRet}"/>
+public readonly struct ParamsFuncSubscriber<T1, T2, TRet>
+{
+    private readonly string _label;
+    private readonly ICallGateSubscriber<T1, T2[], TRet>? _subscriber;
+
+    /// <inheritdoc cref="FuncSubscriber{TRet}.Valid"/>
+    public bool Valid
+        => _subscriber != null;
+
+    public ParamsFuncSubscriber(DalamudPluginInterface pi, string label)
+    {
+        _label = label;
+        try
+        {
+            _subscriber = pi.GetIpcSubscriber<T1, T2[], TRet>(label);
+        }
+        catch (Exception e)
+        {
+            PluginLogHelper.WriteError(pi, $"Error registering IPC Subscriber for {label}\n{e}");
+            _subscriber = null;
+        }
+    }
+
+    /// <inheritdoc cref="FuncSubscriber{TRet}.Invoke"/>
+    public TRet Invoke(T1 a, params T2[] b)
+        => _subscriber != null ? _subscriber.InvokeFunc(a, b) : throw new IpcNotReadyError(_label);
+}
+
+/// <inheritdoc cref="FuncSubscriber{TRet}"/>
 public readonly struct FuncSubscriber<T1, T2, T3, TRet>
 {
     private readonly string                                 _label;

--- a/IPenumbraApi.cs
+++ b/IPenumbraApi.cs
@@ -593,5 +593,16 @@ public interface IPenumbraApi : IPenumbraApiBase
     /// </remarks>
     public IEnumerable<Ipc.ResourceNode>?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects);
 
+    /// <summary>
+    /// Get the player and player-owned game objects' resource trees.
+    /// </summary>
+    /// <param name="withUIData"> Whether to get names and icons along with the paths. </param>
+    /// <returns> A dictionary of game object indices to resource trees. </returns>
+    /// <remarks>
+    /// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
+    /// Also, callers should not use UI data for non-UI purposes.
+    /// </remarks>
+    public IReadOnlyDictionary<ushort, IEnumerable<Ipc.ResourceNode>> GetPlayerResourceTrees(bool withUIData);
+
     #endregion
 }

--- a/IPenumbraApi.cs
+++ b/IPenumbraApi.cs
@@ -581,5 +581,17 @@ public interface IPenumbraApi : IPenumbraApiBase
     public IReadOnlyDictionary<ushort, IReadOnlyDictionary<nint, ( string, string, ChangedItemIcon )>> GetPlayerResourcesOfType(
         ResourceType type, bool withUIData);
 
+    /// <summary>
+    /// Get the given game objects' resource tree.
+    /// </summary>
+    /// <param name="withUIData"> Whether to get names and icons along with the paths. </param>
+    /// <param name="gameObjects"> The game object indices for which to get the resources. </param>
+    /// <returns> An array of resource trees, of the same length and in the same order as the given game object index array. </returns>
+    /// <remarks>
+    /// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
+    /// Also, callers should not use UI data for non-UI purposes.
+    /// </remarks>
+    public IEnumerable<Ipc.ResourceNode>?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects);
+
     #endregion
 }

--- a/IPenumbraApi.cs
+++ b/IPenumbraApi.cs
@@ -591,7 +591,7 @@ public interface IPenumbraApi : IPenumbraApiBase
     /// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
     /// Also, callers should not use UI data for non-UI purposes.
     /// </remarks>
-    public IEnumerable<Ipc.ResourceNode>?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects);
+    public Ipc.ResourceTree?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects);
 
     /// <summary>
     /// Get the player and player-owned game objects' resource trees.
@@ -602,7 +602,7 @@ public interface IPenumbraApi : IPenumbraApiBase
     /// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
     /// Also, callers should not use UI data for non-UI purposes.
     /// </remarks>
-    public IReadOnlyDictionary<ushort, IEnumerable<Ipc.ResourceNode>> GetPlayerResourceTrees(bool withUIData);
+    public IReadOnlyDictionary<ushort, Ipc.ResourceTree> GetPlayerResourceTrees(bool withUIData);
 
     #endregion
 }

--- a/Ipc/ResourceTree.cs
+++ b/Ipc/ResourceTree.cs
@@ -89,4 +89,17 @@ public static partial class Ipc
         public static ParamsFuncSubscriber<bool, ushort, IEnumerable<ResourceNode>?[]> Subscriber(DalamudPluginInterface pi)
             => new(pi, Label);
     }
+
+    /// <inheritdoc cref="IPenumbraApi.GetPlayerResourceTrees"/>
+    public static class GetPlayerResourceTrees
+    {
+        public const string Label = $"Penumbra.{nameof(GetPlayerResourceTrees)}";
+
+        public static FuncProvider<bool, IReadOnlyDictionary<ushort, IEnumerable<ResourceNode>>> Provider(DalamudPluginInterface pi,
+            Func<bool, IReadOnlyDictionary<ushort, IEnumerable<ResourceNode>>> func)
+            => new(pi, Label, func);
+
+        public static ParamsFuncSubscriber<bool, IReadOnlyDictionary<ushort, IEnumerable<ResourceNode>>> Subscriber(DalamudPluginInterface pi)
+            => new(pi, Label);
+    }
 }

--- a/Ipc/ResourceTree.cs
+++ b/Ipc/ResourceTree.cs
@@ -67,7 +67,6 @@ public static partial class Ipc
 
     public record ResourceNode
     {
-        public required int[] ChildrenIndices { get; init; }
         public required ResourceType Type { get; init; }
         public required ChangedItemIcon Icon { get; init; }
         public required string? Name { get; init; }
@@ -75,6 +74,7 @@ public static partial class Ipc
         public required string ActualPath { get; init; }
         public required nint ObjectAddress { get; init; }
         public required nint ResourceHandle { get; init; }
+        public required IEnumerable<ResourceNode> Children { get; init; }
     }
 
     /// <inheritdoc cref="IPenumbraApi.GetGameObjectResourceTrees"/>

--- a/Ipc/ResourceTree.cs
+++ b/Ipc/ResourceTree.cs
@@ -65,6 +65,13 @@ public static partial class Ipc
             => new(pi, Label);
     }
 
+    public record ResourceTree
+    {
+        public required string Name { get; init; }
+        public required ushort RaceCode { get; init; }
+        public required IEnumerable<ResourceNode> Nodes { get; init; }
+    }
+
     public record ResourceNode
     {
         public required ResourceType Type { get; init; }
@@ -82,11 +89,11 @@ public static partial class Ipc
     {
         public const string Label = $"Penumbra.{nameof(GetGameObjectResourceTrees)}";
 
-        public static FuncProvider<bool, ushort[], IEnumerable<ResourceNode>?[]> Provider(DalamudPluginInterface pi,
-            Func<bool, ushort[], IEnumerable<ResourceNode>?[]> func)
+        public static FuncProvider<bool, ushort[], ResourceTree?[]> Provider(DalamudPluginInterface pi,
+            Func<bool, ushort[], ResourceTree?[]> func)
             => new(pi, Label, func);
 
-        public static ParamsFuncSubscriber<bool, ushort, IEnumerable<ResourceNode>?[]> Subscriber(DalamudPluginInterface pi)
+        public static ParamsFuncSubscriber<bool, ushort, ResourceTree?[]> Subscriber(DalamudPluginInterface pi)
             => new(pi, Label);
     }
 
@@ -95,11 +102,11 @@ public static partial class Ipc
     {
         public const string Label = $"Penumbra.{nameof(GetPlayerResourceTrees)}";
 
-        public static FuncProvider<bool, IReadOnlyDictionary<ushort, IEnumerable<ResourceNode>>> Provider(DalamudPluginInterface pi,
-            Func<bool, IReadOnlyDictionary<ushort, IEnumerable<ResourceNode>>> func)
+        public static FuncProvider<bool, IReadOnlyDictionary<ushort, ResourceTree>> Provider(DalamudPluginInterface pi,
+            Func<bool, IReadOnlyDictionary<ushort, ResourceTree>> func)
             => new(pi, Label, func);
 
-        public static ParamsFuncSubscriber<bool, IReadOnlyDictionary<ushort, IEnumerable<ResourceNode>>> Subscriber(DalamudPluginInterface pi)
+        public static FuncSubscriber<bool, IReadOnlyDictionary<ushort, ResourceTree>> Subscriber(DalamudPluginInterface pi)
             => new(pi, Label);
     }
 }

--- a/Ipc/ResourceTree.cs
+++ b/Ipc/ResourceTree.cs
@@ -64,4 +64,29 @@ public static partial class Ipc
             DalamudPluginInterface pi)
             => new(pi, Label);
     }
+
+    public record ResourceNode
+    {
+        public required int[] ChildrenIndices { get; init; }
+        public required ResourceType Type { get; init; }
+        public required ChangedItemIcon Icon { get; init; }
+        public required string? Name { get; init; }
+        public required string? GamePath { get; init; }
+        public required string ActualPath { get; init; }
+        public required nint ObjectAddress { get; init; }
+        public required nint ResourceHandle { get; init; }
+    }
+
+    /// <inheritdoc cref="IPenumbraApi.GetGameObjectResourceTrees"/>
+    public static class GetGameObjectResourceTrees
+    {
+        public const string Label = $"Penumbra.{nameof(GetGameObjectResourceTrees)}";
+
+        public static FuncProvider<bool, ushort[], IEnumerable<ResourceNode>?[]> Provider(DalamudPluginInterface pi,
+            Func<bool, ushort[], IEnumerable<ResourceNode>?[]> func)
+            => new(pi, Label, func);
+
+        public static ParamsFuncSubscriber<bool, ushort, IEnumerable<ResourceNode>?[]> Subscriber(DalamudPluginInterface pi)
+            => new(pi, Label);
+    }
 }

--- a/Ipc/ResourceTree.cs
+++ b/Ipc/ResourceTree.cs
@@ -69,7 +69,7 @@ public static partial class Ipc
     {
         public required string Name { get; init; }
         public required ushort RaceCode { get; init; }
-        public required IEnumerable<ResourceNode> Nodes { get; init; }
+        public required List<ResourceNode> Nodes { get; init; }
     }
 
     public record ResourceNode
@@ -81,7 +81,7 @@ public static partial class Ipc
         public required string ActualPath { get; init; }
         public required nint ObjectAddress { get; init; }
         public required nint ResourceHandle { get; init; }
-        public required IEnumerable<ResourceNode> Children { get; init; }
+        public required List<ResourceNode> Children { get; init; }
     }
 
     /// <inheritdoc cref="IPenumbraApi.GetGameObjectResourceTrees"/>


### PR DESCRIPTION
Adds the ability for a plugin to access the full resource tree of any game object instead of only being able to access specific resources or resource paths.

Docs (in IPenumbraApi):

<details><summary>GetGameObjectResourceTrees</summary>

```csharp
/// <summary>
/// Get the given game objects' resource tree.
/// </summary>
/// <param name="withUIData"> Whether to get names and icons along with the paths. </param>
/// <param name="gameObjects"> The game object indices for which to get the resources. </param>
/// <returns> An array of resource trees, of the same length and in the same order as the given game object index array. </returns>
/// <remarks>
/// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
/// Also, callers should not use UI data for non-UI purposes.
/// </remarks>
public Ipc.ResourceTree?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects);
```
</details>

<details><summary>GetPlayerResourceTrees</summary>

```csharp
/// <summary>
/// Get the player and player-owned game objects' resource trees.
/// </summary>
/// <param name="withUIData"> Whether to get names and icons along with the paths. </param>
/// <returns> A dictionary of game object indices to resource trees. </returns>
/// <remarks>
/// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
/// Also, callers should not use UI data for non-UI purposes.
/// </remarks>
public IReadOnlyDictionary<ushort, Ipc.ResourceTree> GetPlayerResourceTrees(bool withUIData);
```
</details>