### PR TITLE
Update DalamudLibPath to respect environment

### DIFF
--- a/Penumbra.Api.csproj
+++ b/Penumbra.Api.csproj
@@ -45,7 +45,10 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <DalamudLibPath>$(AppData)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
+        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
+        <DalamudLibPath Condition="$(DALAMUD_HOME) != ''">$(DALAMUD_HOME)/</DalamudLibPath>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I'm unable to build project currently from github runner because it doesn't respect DALAMUD_HOME.

This PR bring it in line with the behavior of the default SamplePlugin:
https://github.com/goatcorp/SamplePlugin/blob/7b5d4ee6f2885aacd1abad5bbe72954142543274/SamplePlugin/Dalamud.Plugin.Bootstrap.targets